### PR TITLE
Please pull in is_guest_account

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -891,7 +891,7 @@ class User(ldapdb.models.Model):
         if settings.config.has_key('guestGid'):
             if self.gidNumber == settings.config['guestGid']
                 return True
-         return False
+        return False
 
     def is_allowed_by_hostacl(self, desired_hostname):
         if not self.allowedHost:


### PR DESCRIPTION
Some attributes of a given account shall not be exported from LDAP even
if set, due to the fact that this account is a guest account. We make
the guestGid configurable, as different projects might have different
gidNumbers for that.

Signed-off-by: Martin Zobel-Helas zobel@debian.org
