### PR TITLE
Use AddTrust External Root CA

### DIFF
--- a/src/common/models.py
+++ b/src/common/models.py
@@ -27,7 +27,7 @@ from django.db import models
 from ldapdb.models.fields import CharField, IntegerField, ListField
 import ldapdb.models
 import ldap
-ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, '/etc/ssl/certs/ca-certificates.crt')
+ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, '/etc/ssl/ca-global/AddTrust_External_Root.pem')
 
 import base64
 import datetime


### PR DESCRIPTION
Newer versions of GNUTLS does not allow giving a leaf cert as a CA
cert, so use the root of the chain instead.

This should really live in the settings and not in the source, but
this is to document what's the current state.